### PR TITLE
Crawl zapsign api docs for endpoint errors

### DIFF
--- a/credentials/ZapSignApi.credentials.ts
+++ b/credentials/ZapSignApi.credentials.ts
@@ -45,15 +45,13 @@ export class ZapSignApi implements ICredentialType {
 		properties: {
 			headers: {
 				'Authorization': '=Bearer {{$credentials.apiKey}}',
-				'Content-Type': 'application/json',
-				'Accept': 'application/json',
 			},
 		},
 	};
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: '={{$credentials.environment === "sandbox" ? "https://sandbox.api.zapsign.com.br/" : "https://api.zapsign.com.br/"}}',
+			baseURL: '={{$credentials.environment === "sandbox" ? "https://sandbox.api.zapsign.com.br" : "https://api.zapsign.com.br"}}',
 			url: '/api/v1/docs/?page=1',
 			method: 'GET',
 		},

--- a/nodes/ZapSign/ZapSign.node.ts
+++ b/nodes/ZapSign/ZapSign.node.ts
@@ -508,6 +508,12 @@ export class ZapSign implements INodeType {
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
 
+		// Resolve base URL from credentials once
+		const credentials = await this.getCredentials('zapSignApi');
+		const baseUrl = (credentials as IDataObject).environment === 'sandbox'
+			? 'https://sandbox.api.zapsign.com.br'
+			: 'https://api.zapsign.com.br';
+
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'document') {
@@ -522,7 +528,7 @@ export class ZapSign implements INodeType {
 						// For file upload, we need to use form-data
 						const options: IRequestOptions = {
 							method: 'POST',
-							url: '/v1/documents',
+							url: `${baseUrl}/api/v1/docs`,
 							formData: {
 								name,
 								file: {
@@ -549,7 +555,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'GET',
-							url: `/v1/documents/${documentId}`,
+							url: `${baseUrl}/api/v1/docs/${documentId}`,
 						};
 
 						const responseData = await this.helpers.requestWithAuthentication.call(
@@ -565,7 +571,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'GET',
-							url: '/v1/documents',
+							url: `${baseUrl}/api/v1/docs`,
 							qs: {
 								limit,
 							},
@@ -590,7 +596,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'POST',
-							url: `/v1/documents/${documentId}/send`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/send`,
 							body: {},
 						};
 
@@ -607,7 +613,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'POST',
-							url: `/v1/documents/${documentId}/cancel`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/cancel`,
 							body: {},
 						};
 
@@ -624,7 +630,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'GET',
-							url: `/v1/documents/${documentId}/download`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/download`,
 							encoding: null, // Get binary data
 						};
 
@@ -675,7 +681,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'POST',
-							url: `/v1/documents/${documentId}/signers`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/signers`,
 							body,
 						};
 
@@ -690,7 +696,7 @@ export class ZapSign implements INodeType {
 						// Get all signers
 						const options: IRequestOptions = {
 							method: 'GET',
-							url: `/v1/documents/${documentId}/signers`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/signers`,
 						};
 
 						const responseData = await this.helpers.requestWithAuthentication.call(
@@ -711,7 +717,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'DELETE',
-							url: `/v1/documents/${documentId}/signers/${encodeURIComponent(signerEmail)}`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/signers/${encodeURIComponent(signerEmail)}`,
 						};
 
 						const responseData = await this.helpers.requestWithAuthentication.call(
@@ -743,7 +749,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'PUT',
-							url: `/v1/documents/${documentId}/signers/${encodeURIComponent(signerEmail)}`,
+							url: `${baseUrl}/api/v1/docs/${documentId}/signers/${encodeURIComponent(signerEmail)}`,
 							body,
 						};
 
@@ -762,7 +768,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'GET',
-							url: '/v1/templates',
+							url: `${baseUrl}/api/v1/templates`,
 							qs: {
 								limit,
 							},
@@ -792,7 +798,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'POST',
-							url: '/v1/documents/from-template',
+							url: `${baseUrl}/api/v1/docs/from-template`,
 							body,
 						};
 
@@ -817,7 +823,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'POST',
-							url: '/v1/webhooks',
+							url: `${baseUrl}/api/v1/webhooks`,
 							body,
 						};
 
@@ -834,7 +840,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'GET',
-							url: '/v1/webhooks',
+							url: `${baseUrl}/api/v1/webhooks`,
 							qs: {
 								limit,
 							},
@@ -858,7 +864,7 @@ export class ZapSign implements INodeType {
 
 						const options: IRequestOptions = {
 							method: 'DELETE',
-							url: `/v1/webhooks/${webhookId}`,
+							url: `${baseUrl}/api/v1/webhooks/${webhookId}`,
 						};
 
 						const responseData = await this.helpers.requestWithAuthentication.call(

--- a/nodes/ZapSignTrigger/ZapSignTrigger.node.ts
+++ b/nodes/ZapSignTrigger/ZapSignTrigger.node.ts
@@ -137,13 +137,13 @@ export class ZapSignTrigger implements INodeType {
 
 				const credentials = await this.getCredentials('zapSignApi');
 				const baseUrl = credentials.environment === 'sandbox' 
-					? 'https://sandbox.api.zapsign.com.br/' 
-					: 'https://api.zapsign.com.br/';
+					? 'https://sandbox.api.zapsign.com.br' 
+					: 'https://api.zapsign.com.br';
 
 				try {
 					const response = await this.helpers.request({
 						method: 'GET',
-						url: `${baseUrl}/v1/webhooks`,
+						url: `${baseUrl}/api/v1/webhooks`,
 						headers: {
 							'Authorization': `Bearer ${credentials.apiKey}`,
 							'Content-Type': 'application/json',
@@ -171,8 +171,8 @@ export class ZapSignTrigger implements INodeType {
 
 				const credentials = await this.getCredentials('zapSignApi');
 				const baseUrl = credentials.environment === 'sandbox' 
-					? 'https://sandbox.api.zapsign.com.br/' 
-					: 'https://api.zapsign.com.br/';
+					? 'https://sandbox.api.zapsign.com.br' 
+					: 'https://api.zapsign.com.br';
 
 				const body = {
 					url: webhookUrl,
@@ -183,7 +183,7 @@ export class ZapSignTrigger implements INodeType {
 				try {
 					const responseData = await this.helpers.request({
 						method: 'POST',
-						url: `${baseUrl}/v1/webhooks`,
+						url: `${baseUrl}/api/v1/webhooks`,
 						body,
 						headers: {
 							'Authorization': `Bearer ${credentials.apiKey}`,
@@ -209,13 +209,13 @@ export class ZapSignTrigger implements INodeType {
 				if (webhookData.webhookId !== undefined) {
 					const credentials = await this.getCredentials('zapSignApi');
 					const baseUrl = credentials.environment === 'sandbox' 
-						? 'https://sandbox.api.zapsign.com.br/' 
-						: 'https://api.zapsign.com.br/';
+						? 'https://sandbox.api.zapsign.com.br' 
+						: 'https://api.zapsign.com.br';
 
 					try {
 						await this.helpers.request({
 							method: 'DELETE',
-							url: `${baseUrl}/v1/webhooks/${webhookData.webhookId}`,
+							url: `${baseUrl}/api/v1/webhooks/${webhookData.webhookId}`,
 							headers: {
 								'Authorization': `Bearer ${credentials.apiKey}`,
 							},


### PR DESCRIPTION
Fixes 'Invalid URL' errors and enables file uploads by correcting ZapSign API paths and base URL construction.

The node was generating incorrect URLs (e.g., `/v1/documents` instead of `/api/v1/docs`) and the credentials forced `Content-Type: application/json`, which broke multipart file uploads. This PR updates the node and trigger to use the correct `/api/v1` paths and constructs absolute URLs, while also removing the problematic `Content-Type` header from credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ef2cd7d-d5ae-4858-99ed-3a2aaed9bf1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ef2cd7d-d5ae-4858-99ed-3a2aaed9bf1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

